### PR TITLE
Allow to set `network_mode` for task.

### DIFF
--- a/modules/task/main.tf
+++ b/modules/task/main.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_task_definition" "task" {
   }])
 
   requires_compatibilities = ["FARGATE"]
-  network_mode             = "awsvpc"
+  network_mode             = var.network_mode
   cpu                      = var.cpu
   memory                   = var.memory
   tags                     = var.tags

--- a/modules/task/variables.tf
+++ b/modules/task/variables.tf
@@ -71,4 +71,7 @@ variable "task_role_arn" {
   type    = string
 }
 
-
+variable "network_mode" {
+  type    = string
+  default = "awsvpc"
+}


### PR DESCRIPTION
We don’t require it everywhere, so we should be able to set it to `none`.