### PR TITLE
Revert "Allow to set `network_mode` for task."

### DIFF
--- a/modules/task/main.tf
+++ b/modules/task/main.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_task_definition" "task" {
   }])
 
   requires_compatibilities = ["FARGATE"]
-  network_mode             = var.network_mode
+  network_mode             = "awsvpc"
   cpu                      = var.cpu
   memory                   = var.memory
   tags                     = var.tags

--- a/modules/task/variables.tf
+++ b/modules/task/variables.tf
@@ -71,7 +71,4 @@ variable "task_role_arn" {
   type    = string
 }
 
-variable "network_mode" {
-  type    = string
-  default = "awsvpc"
-}
+


### PR DESCRIPTION
This reverts commit 4bbe0adba5e672552f1b2aadfa6f4cfa7d79a4e9.

Because:
```
│ Error: ClientException: Fargate only supports network mode ‘awsvpc’.
```

https://app.terraform.io/app/epsy/workspaces/apps_insights_recalculation_staging/runs/run-uU5XQFiqwRs7a3VN